### PR TITLE
(feat) Add hook for CPU cores / hardware-concurrency (fixes #34)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -34,6 +34,22 @@ const MyComponent = () => {
 };
 ```
 
+## CPU Cores / Hardware Concurrency
+React hook for getting CPU cores of the device
+
+```js
+import { useHardwareConcurrency } from './hardware-concurrency';
+
+const MyComponent = () => {
+  const { cores } = useHardwareConcurrency();
+  return (
+    <div>
+      { cores <= 4 ? <img src='...' /> : <video src='...' /> }
+    </div>
+  );
+};
+```
+
 ## Memory
 React hook for getting memory status of the device
 
@@ -41,26 +57,10 @@ React hook for getting memory status of the device
 import { useMemoryStatus } from './memory';
 
 const MyComponent = () => {
-  const { overLoad } = useMemoryStatus();
+  const { overLoaded } = useMemoryStatus();
   return (
     <div>
-      { overLoad ? <img src='...' /> : <video src='...' /> }
-    </div>
-  );
-};
-```
-
-## Device-class
-React hook for getting device-class whether it's light or heavy
-
-```js
-import { useDeviceClass } from './device-class';
-
-const MyComponent = () => {
-  const deviceClass = useDeviceClass();
-  return (
-    <div>
-      { deviceClass === ‘light’ ? <img src='...' /> : <video src='...' /> }
+      { overLoaded ? <img src='...' /> : <video src='...' /> }
     </div>
   );
 };
@@ -77,6 +77,22 @@ const MyComponent = () => {
   return (
     <div>
       { batteryStatus.level > 0.75 ? <video src='...' /> : <img src='...' /> }
+    </div>
+  );
+};
+```
+
+## Device-class
+React hook for getting device-class whether it's light or heavy
+
+```js
+import { useDeviceClass } from './device-class';
+
+const MyComponent = () => {
+  const deviceClass = useDeviceClass();
+  return (
+    <div>
+      { deviceClass === ‘light’ ? <img src='...' /> : <video src='...' /> }
     </div>
   );
 };

--- a/hooks/device-class/index.js
+++ b/hooks/device-class/index.js
@@ -27,7 +27,7 @@ const useDeviceClass = () => {
     parser.setUA(uastring);
     const device = parser.getDevice();
     const model = device.model;
-    console.log('[useDeviceClass] device model => ', model);
+    // console.log('[useDeviceClass] device model => ', model);
 
     // Match against devices you consider low-end
     const lowEnd = [
@@ -41,7 +41,7 @@ const useDeviceClass = () => {
 
     // Optional: map to device-year-class, Geekbench.
     setDeviceClass(lowEnd.indexOf(model) > 0 ? 'light' : 'heavy');
-  },[]);
+  }, []);
 
   return deviceClass;
 };

--- a/hooks/hardware-concurrency/concurrency.test.js
+++ b/hooks/hardware-concurrency/concurrency.test.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useHardwareConcurrency } from './';
+
+describe('useHardwareConcurrency', () => {
+
+    test('should return 4 for device of hardwareConcurrency = 4', () => {
+        Object.defineProperty(window.navigator, "hardwareConcurrency", {
+            value: 4,
+            configurable: true,
+            writable: true
+        });
+        const { result } = renderHook(() => useHardwareConcurrency());
+
+        expect(result.current.hardwareConcurrency).toEqual(4);
+    });
+
+    test('should return 2 for device of hardwareConcurrency = 2', () => {
+        Object.defineProperty(window.navigator, "hardwareConcurrency", {
+            value: 2,
+            configurable: true,
+            writable: true
+        });
+        const { result } = renderHook(() => useHardwareConcurrency());
+
+        expect(result.current.hardwareConcurrency).toEqual(2);
+    });
+});

--- a/hooks/hardware-concurrency/index.js
+++ b/hooks/hardware-concurrency/index.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+export const unsupportMessage = 'The Hardware Concurrency API is not supported on this platform.';
+
+const useHardwareConcurrency = () => {
+    const [hardwareConcurrency, setHardwareConcurrency] = useState(null);
+
+    useEffect(() => {
+        if ('hardwareConcurrency' in navigator) {
+            setHardwareConcurrency(navigator.hardwareConcurrency);
+        } else {
+            setHardwareConcurrency({ unsupportMessage });
+        }
+    }, []);
+
+    return { hardwareConcurrency };
+};
+
+export { useHardwareConcurrency };


### PR DESCRIPTION
This is an initial implementation of a hook for `navigator.hardwareConcurrency`. It currently just exposes the raw values, deferring to the developer to use the cores for classification.

We may (more generally) want to decide if it is better for these hooks to expose a classification (light/heavy, slow/fast) or if raw values make more sense.